### PR TITLE
Restore waitlist API and frontend features

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn backend.server:app --host 0.0.0.0 --port $PORT

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Here are your Instructions
+# Deployment Instructions
+
+This project contains a FastAPI backend and React frontend. To deploy the backend to Heroku:
+
+1. Ensure you have the Heroku CLI installed and you are logged in with `heroku login`.
+2. Create a new Heroku app:
+
+   ```bash
+   heroku create YOUR_APP_NAME
+   ```
+
+3. Set required environment variables:
+
+   ```bash
+   heroku config:set MONGO_URL=your_mongo_url DB_NAME=evolance
+   heroku config:set EMAILJS_API_KEY=your_emailjs_key EMAILJS_ACCOUNT_ID=your_emailjs_account
+   ```
+
+4. Push the repository to Heroku:
+
+   ```bash
+   git push heroku work:main
+   ```
+
+Heroku will use the included `Procfile` to launch the backend using Uvicorn.

--- a/backend/server.py
+++ b/backend/server.py
@@ -64,69 +64,89 @@ class WaitlistEntryCreate(BaseModel):
 # Add your routes to the router instead of directly to app
 @api_router.get("/")
 async def root():
+    logger.info("Root endpoint called")
     return {"message": "Hello World"}
 
 
 @api_router.post("/status", response_model=StatusCheck)
 async def create_status_check(input: StatusCheckCreate):
+    logger.info("Create status check with input: %s", input.dict())
     status_dict = input.dict()
     status_obj = StatusCheck(**status_dict)
     if db:
         await db.status_checks.insert_one(status_obj.dict())
+        logger.info("Status check stored in DB: %s", status_obj.id)
         return status_obj
+    logger.warning("Database not configured; status check not saved")
     raise HTTPException(status_code=503, detail="Database not configured")
 
 
 @api_router.get("/status", response_model=List[StatusCheck])
 async def get_status_checks():
+    logger.info("Fetch status checks")
     if not db:
+        logger.warning("Database not configured; cannot fetch status checks")
         raise HTTPException(status_code=503, detail="Database not configured")
     status_checks = await db.status_checks.find().to_list(1000)
+    logger.info("Fetched %d status checks", len(status_checks))
     return [StatusCheck(**status_check) for status_check in status_checks]
 
 
 # Waitlist endpoints
 def _load_waitlist() -> List[dict]:
+    logger.debug("Loading waitlist from %s", WAITLIST_FILE)
     if WAITLIST_FILE.exists():
         try:
-            return json.loads(WAITLIST_FILE.read_text())
-        except Exception:
+            data = json.loads(WAITLIST_FILE.read_text())
+            logger.debug("Loaded %d waitlist entries", len(data))
+            return data
+        except Exception as exc:
+            logger.error("Failed reading waitlist file: %s", exc)
             return []
+    logger.debug("Waitlist file not found")
     return []
 
 
 def _save_waitlist(entries: List[dict]) -> None:
     """Persist waitlist entries to the JSON file."""
+    logger.debug("Saving %d waitlist entries to %s", len(entries), WAITLIST_FILE)
     WAITLIST_FILE.write_text(json.dumps(entries, default=str, indent=2))
 
 
 @api_router.post("/waitlist", response_model=WaitlistEntry)
 async def create_waitlist_entry(input: WaitlistEntryCreate):
+    logger.info("Create waitlist entry: %s", input.dict())
     entry_obj = WaitlistEntry(**input.dict())
     if db:
         await db.waitlist.insert_one(entry_obj.dict())
+        logger.info("Waitlist entry stored in DB: %s", entry_obj.id)
     else:
         data = _load_waitlist()
         data.append(entry_obj.dict())
         _save_waitlist(data)
+        logger.info("Waitlist entry saved locally: %s", entry_obj.id)
     return entry_obj
 
 
 @api_router.get("/waitlist", response_model=List[WaitlistEntry])
 async def get_waitlist_entries():
+    logger.info("Fetch waitlist entries")
     if db:
         entries = await db.waitlist.find().to_list(1000)
     else:
         entries = _load_waitlist()
+    logger.info("Retrieved %d waitlist entries", len(entries))
     return [WaitlistEntry(**entry) for entry in entries]
 
 
 @api_router.get("/waitlist/count")
 async def get_waitlist_count():
+    logger.info("Fetch waitlist count")
     if db:
         count = await db.waitlist.count_documents({})
     else:
         count = len(_load_waitlist())
+    logger.info("Waitlist count is %d", count)
     return {"count": count}
 
 
@@ -136,11 +156,11 @@ async def get_emailjs_contacts_count():
     api_key = os.getenv("EMAILJS_API_KEY")
     account_id = os.getenv("EMAILJS_ACCOUNT_ID")
     if not api_key or not account_id:
-        logging.error("EmailJS credentials not configured")
+        logger.error("EmailJS credentials not configured")
         return {"count": len(_load_waitlist())}
 
     if requests is None:
-        logging.error("requests library not installed")
+        logger.error("requests library not installed")
         return {"count": len(_load_waitlist())}
 
     headers = {
@@ -149,23 +169,29 @@ async def get_emailjs_contacts_count():
     }
     url = f"https://api.emailjs.com/api/v1/accounts/{account_id}/contacts"
     try:
+        logger.debug("Requesting EmailJS contacts count")
         resp = requests.get(url, headers=headers, timeout=10)
         resp.raise_for_status()
         data = resp.json()
-        return {"count": len(data.get("contacts", []))}
+        count = len(data.get("contacts", []))
+        logger.info("EmailJS contacts count is %d", count)
+        return {"count": count}
     except Exception as exc:
-        logging.error("Failed fetching EmailJS contacts: %s", exc)
+        logger.error("Failed fetching EmailJS contacts: %s", exc)
         return {"count": len(_load_waitlist())}
 
 
 @api_router.delete("/waitlist")
 async def clear_waitlist():
+    logger.info("Clear waitlist")
     if db:
         result = await db.waitlist.delete_many({})
         deleted = result.deleted_count
+        logger.info("Deleted %d entries from DB", deleted)
     else:
         _save_waitlist([])
         deleted = 0
+        logger.info("Local waitlist cleared")
     return {"deleted": deleted}
 
 
@@ -180,9 +206,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Configure logging
+# Configure logging with environment variable
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
-    level=logging.INFO,
+    level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)

--- a/test_result.md
+++ b/test_result.md
@@ -173,3 +173,7 @@ agent_communication:
     message: "Added local file fallback for waitlist and improved count fetching"
   - agent: "main"
     message: "Fixed waitlist JSON save bug and ensured counter visibility"
+  - agent: "main"
+    message: "Reverted prior cleanup to restore waitlist features"
+  - agent: "main"
+    message: "Added detailed logging and Heroku deployment guide"


### PR DESCRIPTION
## Summary
- revert the previous revert to bring back waitlist and EmailJS features
- document restored work in testing logs
- add logging to backend and provide Heroku deployment docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851f461c57c8324962a929444ad54c8